### PR TITLE
Revert: download button modification

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -45,7 +45,7 @@ img.mfp-img {
   a.image-source-link {
     &:first-child {
       visibility: visible;
-      @include mfp-align;
+      position: fixed;
       @include button-position(auto, 0, 0, auto);
       .mobile-view & {
         @include button-position(0, auto, 0, auto);

--- a/common/common.scss
+++ b/common/common.scss
@@ -33,27 +33,33 @@ img.mfp-img {
 
 // Title
 
-.mfp-title {
-  display: none;
+@if $hide-download-button == "true" {
+  .mfp-title {
+    display: none;
+  }
 }
 
-// Download button
-
-.image-source-link {
-  @include mfp-align;
-  left: 10px;
-  bottom: 10px;
-  .mobile-view & {
-    top: 10px;
-  }
-  @include mfp-bg-color-op;
-  font-size: 1.2em;
-  cursor: pointer;
-  @include mfp-btn-shadow(40px, 50%);
-  z-index: 1046;
-  &:hover {
-    opacity: 1;
-    color: #000;
+.mfp-title {
+  visibility: hidden;
+  // Download button
+  a.image-source-link {
+    &:first-child {
+      visibility: visible;
+      @include mfp-align;
+      @include button-position(auto, 0, 0, auto);
+      .mobile-view & {
+        @include button-position(0, auto, 0, auto);
+      }
+      @include mfp-bg-color-op;
+      font-size: var(--font-down-2);
+      cursor: pointer;
+      border: 5px solid transparent;
+      z-index: 1046;
+      &:hover {
+        opacity: 1;
+        color: #000;
+      }
+    }
   }
 }
 
@@ -225,59 +231,26 @@ button.mfp-arrow {
 
 .mobile-view {
   // Close and Zoom button position
-  @if $close-zoom-button-position-mobile == "top right" {
+  @if $buttons-position-mobile == "close and zoom top right, download top left" {
     .mfp-close-btn-in .mfp-close {
       @include button-position(10px, auto, auto, 10px);
     }
     .full-size-btn {
       @include button-position(10px, auto, auto, 60px);
     }
-    @if $download-button-position-mobile == "bottom left" {
-      .image-source-link {
-        @include button-position(auto !important, 10px !important, 10px !important, auto !important);
-      }
-    }
-    @if $download-button-position-mobile == "top right" {
-      .image-source-link {
-        @include button-position(10px !important, auto !important, auto !important, 110px !important);
-      }
-    } 
-  }
-  
-  @if $close-zoom-button-position-mobile == "bottom right" {
-    .mfp-close-btn-in .mfp-close {
-      @include button-position(auto, 10px, auto, 10px);
-    }
-    .full-size-btn {
-      @include button-position(auto, 10px, auto, 60px);
-    }
-    // Download button position
-    @if $download-button-position-mobile == "bottom left" {
-      .image-source-link {
-        @include button-position(auto !important, 10px !important, 10px !important, auto !important);
-      }
-    }
-    @if $download-button-position-mobile == "bottom right" {
-      .image-source-link {
-        @include button-position(auto !important, 10px !important, auto !important, 110px !important);
-      }
-    }
-  }
-  
-  // Download button position
-  @if $download-button-position-mobile == "top right" {
     .image-source-link {
+      @include button-position(0 !important, auto !important, 0 !important, auto !important);
+    }
+  }
+  @if $buttons-position-mobile == "close and zoom top right, download bottom left" {
+    .mfp-close-btn-in .mfp-close {
       @include button-position(10px, auto, auto, 10px);
     }
-  }
-  @if $download-button-position-mobile == "bottom left" {
-    .image-source-link {
-      @include button-position(auto, 10px, 110px, auto);
+    .full-size-btn {
+      @include button-position(10px, auto, auto, 60px);
     }
-  }
-  @if $download-button-position-mobile == "bottom right" {
     .image-source-link {
-      @include button-position(auto, 10px, auto, 10px);
+      @include button-position(auto !important, 0 !important, 0 !important, auto !important);
     }
   }
 }

--- a/javascripts/discourse/initializers/custom-lightbox.js
+++ b/javascripts/discourse/initializers/custom-lightbox.js
@@ -13,7 +13,7 @@ export default {
       );
         
       let zoomInIcon = iconHTML(settings.zoom_in_icon, {
-        class: "mfp-prevent-close" 
+        class: "mfp-prevent-close"
       });
       
       let zoomOutIcon = iconHTML(settings.zoom_out_icon, {
@@ -40,36 +40,7 @@ export default {
       minusButton.innerHTML = zoomOutIcon;
       buttonsContainer.append(minusButton);
 
-      // Download button
-      let downloadIcon = iconHTML(settings.download_icon, {
-        class: "mfp-prevent-close"
-      });
-      const sourceLink = $(".mfp-container .image-source-link");
-      const downloadLink = $('.mfp-title a.image-source-link[href*="short-url"]');
-      const appendedLink = $('.mfp-container a.image-source-link[href*="short-url"]');
-
-      // Prevent close lightbox by clicking download button 
-      sourceLink.addClass("mfp-prevent-close");
-      // Add title to download button
-      sourceLink.title = I18n.t("lightbox.download");
-
-      // Remove the last download button when change image in gallery
-      if (
-        appendedLink.length > 1 ||
-        appendedLink.length > 1 &&
-        e.keyCode == 37 ||
-        appendedLink.length > 1 &&
-        e.keyCode == 39
-      ) {
-        appendedLink.last().remove();
-      }
-        
       const mfpContainer = $(".mfp-container");
-      // Move download button to mfp-container so it will always a fixed position
-      mfpContainer.append(downloadLink);
-
-      // Remove download text and only use icon
-      sourceLink.html(downloadIcon);
         
       const mfpClose = $(".mfp-close");
       // Move close button to mfp-container so it will always a fixed position

--- a/settings.yml
+++ b/settings.yml
@@ -6,27 +6,18 @@ zoom_out_icon:
   default: search-minus
   type: "string"
   description: "You can change the (zoom out) button icon here."
-download_icon:
-  default: download
-  type: "string"
-  description: "You can change the (download) button icon here."
 svg_icons: 
   default: "search-plus|search-minus"
   type: "list"
   list_type: "compact"
   description: "List of FontAwesome 5 icons used in this theme component"
-close_zoom_button_position_mobile:
-  default: bottom left
+hide_download_button:
+  default: false
+  type: "bool"
+buttons_position_mobile:
+  default: close and zoom bottom left, download top left
   type: enum
   choices:
-    - top right
-    - bottom right 
-  description: "Close and Download button position on mobile."
-download_button_position_mobile:
-  default: top left
-  type: enum
-  choices:
-    - bottom left
-    - bottom right
-    - top right
-  description: "Download button position on mobile."
+    - close and zoom top right, download top left
+    - close and zoom top right, download bottom left
+  description: "Close, Zoom and Download buttons position on mobile."


### PR DESCRIPTION
I have to revert the download button modifications and find a better way. There was some issue on mobile... So I use the default download button instead of create and modify it.

This update contains:
1. revert download button modification
2. style the default download button with css
3. add setting to hide the download button
4. change the positioning settings to ⬇️ 
![Screenshot 2022-05-04 at 15 55 05](https://user-images.githubusercontent.com/71207900/166696366-e442f588-f4d3-41df-9471-9a5ee72325d0.png)


