### PR TITLE
Dev: drop the default close button and create a new one

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -87,23 +87,26 @@ img.mfp-img {
 // Buttons
 
 .mfp-close-btn-in .mfp-close {
-  display: block;
+  display: none;
+}
+
+.close-btn {
+  @include mfp-align;
   position: fixed;
-  text-align: center;
   right: 20px;
   top: 20px;
+  font-size: 1.2em;
+  border: none;
+  padding: 0;
+  @include mfp-bg-color-op;
+  @include mfp-btn-shadow(40px, 50%);
+  cursor: pointer;
+  z-index: 1046;
   .mobile-view & {
-    display: flex;
-    align-items: center;
-    justify-content: center;
     left: 10px;
     bottom: 10px;
     top: auto;
   }
-  padding: 0;
-  @include mfp-bg-color-op;
-  @include mfp-btn-shadow(40px, 50%);
-  cursor: pointer !important;
   &:hover {
     opacity: 1;
   }
@@ -195,13 +198,11 @@ button.mfp-arrow {
     @include button-position(auto, 10px, 60px, auto);
   }
   button {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    @include mfp-align;
     @include mfp-bg-color-op;
+    @include mfp-btn-shadow(40px, 50%);
     font-size: 1.2em;
     cursor: pointer;
-    @include mfp-btn-shadow(40px, 50%);
     border: none;
     &:hover {
       opacity: 1;
@@ -247,7 +248,7 @@ button.mfp-arrow {
 .mobile-view {
   // Close and Zoom button position
   @if $buttons-position-mobile == "close and zoom top right, download top left" {
-    .mfp-close-btn-in .mfp-close {
+    .close-btn {
       @include button-position(10px, auto, auto, 10px);
     }
     .full-size-btn {
@@ -258,7 +259,7 @@ button.mfp-arrow {
     }
   }
   @if $buttons-position-mobile == "close and zoom top right, download bottom left" {
-    .mfp-close-btn-in .mfp-close {
+    .close-btn {
       @include button-position(10px, auto, auto, 10px);
     }
     .full-size-btn {

--- a/javascripts/discourse/initializers/custom-lightbox.js
+++ b/javascripts/discourse/initializers/custom-lightbox.js
@@ -5,13 +5,14 @@ export default {
   initialize() {
     $("body").on("click", function() {
       
-      // Custom Buttons
+      // Create zoom buttons container
       const buttonsContainer = document.createElement('div');
       buttonsContainer.classList.add(
         "full-size-btn",
         "mfp-prevent-close"
       );
-        
+      
+      // Create icons 
       let zoomInIcon = iconHTML(settings.zoom_in_icon, {
         class: "mfp-prevent-close"
       });
@@ -19,7 +20,9 @@ export default {
       let zoomOutIcon = iconHTML(settings.zoom_out_icon, {
         class: "mfp-prevent-close"
       });
-        
+      
+      let closeIcon = iconHTML(settings.close_icon);
+      
       // Create Plus Button
       const plusButton = document.createElement('button');
       plusButton.classList.add(
@@ -39,30 +42,36 @@ export default {
       minusButton.title = I18n.t(themePrefix("zoom_out_button_title"));
       minusButton.innerHTML = zoomOutIcon;
       buttonsContainer.append(minusButton);
+      
+      // Create Close Button
+      const closeButton = document.createElement('button');
+      closeButton.classList.add(
+        "close-btn"
+      );
+      closeButton.title = I18n.t(themePrefix("close_button_title"));
+      closeButton.innerHTML = closeIcon;
 
-      const mfpContainer = $(".mfp-container");
-        
-      const mfpClose = $(".mfp-close");
-      // Move close button to mfp-container so it will always a fixed position
-      mfpContainer.append(mfpClose);
-
+      // Add buttons function
       const mfpWrap = $(".mfp-wrap");
-      // Add zoom button function
+      const mfpContainer = $(".mfp-container");
       if ($(".full-size-btn").length <= 0){
         mfpContainer.append(buttonsContainer);
         $(".full-size-btn").click(function() {
           mfpWrap.toggleClass("mfp-full-size-scrollbars");
         });
       }
-        
-      const mfpImg = $(".mfp-img");
+      if ($(".close-btn").length <= 0) {
+        mfpContainer.append(closeButton);
+      }      
+      
       // Prevent image click zoom in desktop. Only can zoom with the zoom button.
+      const mfpImg = $(".mfp-img");
       $(document).on("click", ".mfp-img", function() {
         mfpImg.css("max-height", $(window).height());
       });
-                
-      const mfpImgAndArrow = $(".mfp-img, .mfp-arrow");       
+      
       // If the image zoomed in, than click the image or the arrows will zoom out.
+      const mfpImgAndArrow = $(".mfp-img, .mfp-arrow");
       mfpImgAndArrow.click(function() {
         if (mfpWrap.hasClass("mfp-full-size-scrollbars")) {
           mfpWrap.removeClass("mfp-full-size-scrollbars");

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,3 +1,4 @@
 en:
   zoom_in_button_title: "Zoom In"
   zoom_out_button_title: "Zoom Out"
+  close_button_title: "Close (Esc)"

--- a/scss/custom-lightbox-mixin.scss
+++ b/scss/custom-lightbox-mixin.scss
@@ -14,6 +14,12 @@
   opacity: .65;
 }
 
+@mixin mfp-align {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 // Mobile Buttons Position
 
 @mixin button-position($top, $bottom, $left, $right) {

--- a/settings.yml
+++ b/settings.yml
@@ -6,6 +6,10 @@ zoom_out_icon:
   default: search-minus
   type: "string"
   description: "You can change the (zoom out) button icon here."
+close_icon:
+  default: times
+  type: "string"
+  description: "You can change the (close) button icon here."  
 svg_icons: 
   default: "search-plus|search-minus"
   type: "list"


### PR DESCRIPTION
The close button is not using Fontawesome icon by default. We have to create a new close button to have the ability using Fontawesome icon. This is make the zoom and close icons more similar and we can more align the close icon on cross platforms. I added a new settings to change the close button icon and new theme translate for close button title.