### PR TITLE
Fix: Discourse Chat compatibility issue

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -95,7 +95,7 @@ img.mfp-img {
   display: none;
 }
 
-.close-btn {
+.close-lightbox-btn {
   @include mfp-align;
   position: fixed;
   right: 20px;
@@ -253,7 +253,7 @@ button.mfp-arrow {
 .mobile-view {
   // Close and Zoom button position
   @if $buttons-position-mobile == "close and zoom top right, download top left" {
-    .close-btn {
+    .close-lightbox-btn {
       @include button-position(10px, auto, auto, 10px);
     }
     .full-size-btn {
@@ -264,7 +264,7 @@ button.mfp-arrow {
     }
   }
   @if $buttons-position-mobile == "close and zoom top right, download bottom left" {
-    .close-btn {
+    .close-lightbox-btn {
       @include button-position(10px, auto, auto, 10px);
     }
     .full-size-btn {

--- a/javascripts/discourse/initializers/custom-lightbox.js
+++ b/javascripts/discourse/initializers/custom-lightbox.js
@@ -46,7 +46,7 @@ export default {
       // Create Close Button
       const closeButton = document.createElement('button');
       closeButton.classList.add(
-        "close-btn"
+        "close-lightbox-btn"
       );
       closeButton.title = I18n.t(themePrefix("close_button_title"));
       closeButton.innerHTML = closeIcon;
@@ -60,7 +60,7 @@ export default {
           mfpWrap.toggleClass("mfp-full-size-scrollbars");
         });
       }
-      if ($(".close-btn").length <= 0) {
+      if ($(".close-lightbox-btn").length <= 0) {
         mfpContainer.append(closeButton);
       }      
       


### PR DESCRIPTION
Discourse Chat uses the same `.close-btn` class what we use on Custom Lightbox close button. In this update I change the close button class to more specific one. The new class we use: `.close-lightbox-btn`.